### PR TITLE
Remove timestamp

### DIFF
--- a/src/MonologStackdriverHandler.php
+++ b/src/MonologStackdriverHandler.php
@@ -36,8 +36,7 @@ class MonologStackdriverHandler extends AbstractProcessingHandler
             ],
             'labels' => [
                 'project_id' => $googleProjectId,
-            ],
-            'timestamp' => date('Y-m-dTH:i:sZ'),
+            ]
         ], $options);
     }
 


### PR DESCRIPTION
The timestamp format string does not produce the RFC3339 UTC "Zulu" format required by Stackdriver. It can be omitted, and StackDriver will assign the current timestamp automatically.