### PR TITLE
generate valid RFC3339 timestamp by default

### DIFF
--- a/src/MonologStackdriverHandler.php
+++ b/src/MonologStackdriverHandler.php
@@ -37,7 +37,7 @@ class MonologStackdriverHandler extends AbstractProcessingHandler
             'labels' => [
                 'project_id' => $googleProjectId,
             ],
-            'timestamp' => date('Y-m-dTH:i:sZ'),
+            'timestamp' => (new \DateTime())->format(\DateTime::RFC3339),
         ], $options);
     }
 


### PR DESCRIPTION
instead of removing the timestamp completely, like referenced in #3, we now generate a correct RFC3339 timestamp.